### PR TITLE
Node search improvements

### DIFF
--- a/css/litegraph.css
+++ b/css/litegraph.css
@@ -184,6 +184,7 @@
     color: white;
     padding-left: 10px;
     margin-right: 5px;
+    max-width: 300px;
 }
 
 .litegraph.litesearchbox .name {
@@ -226,6 +227,18 @@
     background-color: white;
     color: black;
 }
+
+.litegraph.lite-search-item-type {
+    display: inline-block;
+    background: rgba(0,0,0,0.2);
+    margin-left: 5px;
+    font-size: 14px;
+    padding: 2px 5px;
+    position: relative;
+    top: -2px;
+    opacity: 0.8;
+    border-radius: 4px;
+ }
 
 /* DIALOGs ******/
 

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -11908,7 +11908,7 @@ LGraphNode.prototype.executeAction = function(action)
 					var ctor = LiteGraph.registered_node_types[ type ];
 					if(filter && ctor.filter != filter )
 						return false;
-                    if ((!options.show_all_if_empty || str) && type.toLowerCase().indexOf(str) === -1)
+                    if ((!options.show_all_if_empty || str) && type.toLowerCase().indexOf(str) === -1 && (!ctor.title || ctor.title.toLowerCase().indexOf(str) === -1))
                         return false;
                     
                     // filter by slot IN, OUT types
@@ -11962,7 +11962,18 @@ LGraphNode.prototype.executeAction = function(action)
                 if (!first) {
                     first = type;
                 }
-                help.innerText = type;
+
+                const nodeType = LiteGraph.registered_node_types[type];
+                if (nodeType?.title) {
+                    help.innerText = nodeType?.title;
+                    const typeEl = document.createElement("span");
+                    typeEl.className = "litegraph lite-search-item-type";
+                    typeEl.textContent = type;
+                    help.append(typeEl);
+                } else {
+                    help.innerText = type;
+                }
+
                 help.dataset["type"] = escape(type);
                 help.className = "litegraph lite-search-item";
                 if (className) {


### PR DESCRIPTION
- Show node title in search as the primary text, type name as secondary
- Filter by searching title + type
- Fix long types overflowing dialog

![image](https://github.com/comfyanonymous/litegraph.js/assets/125205205/005b29e7-6a4c-4d7d-b0d3-831d9fa61c41)
