### PR TITLE
centerOnNode DPI fix

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -7556,11 +7556,11 @@ LGraphNode.prototype.executeAction = function(action)
         this.ds.offset[0] =
             -node.pos[0] -
             node.size[0] * 0.5 +
-            (this.canvas.width * 0.5) / this.ds.scale;
+            (this.canvas.width * 0.5) / (this.ds.scale * window.devicePixelRatio);
         this.ds.offset[1] =
             -node.pos[1] -
             node.size[1] * 0.5 +
-            (this.canvas.height * 0.5) / this.ds.scale;
+            (this.canvas.height * 0.5) / (this.ds.scale * window.devicePixelRatio);
         this.setDirty(true, true);
     };
 


### PR DESCRIPTION
[this](https://github.com/comfyanonymous/ComfyUI/commit/4796e615dd7faad38429fc8e716e3a817a28c526) broke centerOnNode  for zoomed browsers. Added back the DPI fix just for centering. 