### PR TITLE
Alt+Shift+Drag clones nodes with incoming connections

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -5922,7 +5922,24 @@ LGraphNode.prototype.executeAction = function(action)
             // clone node ALT dragging
             if (LiteGraph.alt_drag_do_clone_nodes && e.altKey && node && this.allow_interaction && !skip_action && !this.read_only)
             {
-                if (cloned = node.clone()){
+                // nodes already selected
+                if (Object.keys(this.selected_nodes).length) {
+                    var clipboard_info = this.prepareDataForClipboard()
+
+                    var isConnectUnselected = e.shiftKey
+
+                    this.graph.beforeChange();
+                    //create nodes
+                    this.pasteFromClipboardWithData(clipboard_info, isConnectUnselected, false);
+                    skip_action = true;
+
+                    // drag newly duplicated node under the cursor
+                    node = this.graph.getNodeOnPos( e.canvasX, e.canvasY, this.visible_nodes, 5 );
+                    this.node_dragged = node;
+
+                    this.graph.afterChange();
+                }
+                else if (cloned = node.clone()){
                     cloned.pos[0] += 5;
                     cloned.pos[1] += 5;
                     this.graph.add(cloned,false,{doCalcSize: false});
@@ -7134,7 +7151,7 @@ LGraphNode.prototype.executeAction = function(action)
         }
     };
 
-    LGraphCanvas.prototype.copyToClipboard = function(nodes) {
+    LGraphCanvas.prototype.prepareDataForClipboard = function(nodes) {
         var clipboard_info = {
             nodes: [],
             links: []
@@ -7186,45 +7203,50 @@ LGraphNode.prototype.executeAction = function(action)
                 }
             }
         }
+        return clipboard_info;
+    }
+
+    LGraphCanvas.prototype.copyToClipboard = function(nodes) {
+        var clipboard_info = this.prepareDataForClipboard(nodes);        
         localStorage.setItem(
             "litegrapheditor_clipboard",
             JSON.stringify(clipboard_info)
         );
     };
 
-    LGraphCanvas.prototype.pasteFromClipboard = function(isConnectUnselected = false) {
-        // if ctrl + shift + v is off, return when isConnectUnselected is true (shift is pressed) to maintain old behavior
-        if (!LiteGraph.ctrl_shift_v_paste_connect_unselected_outputs && isConnectUnselected) {
-            return;
-        }
-        var data = localStorage.getItem("litegrapheditor_clipboard");
-        if (!data) {
-            return;
-        }
-
-		this.graph.beforeChange();
-
-        //create nodes
-        var clipboard_info = JSON.parse(data);
+    LGraphCanvas.prototype.pasteFromClipboardWithData = function(clipboard_info, isConnectUnselected = false, calculatePasteOffset = true) {
         // calculate top-left node, could work without this processing but using diff with last node pos :: clipboard_info.nodes[clipboard_info.nodes.length-1].pos
         var posMin = false;
         var posMinIndexes = false;
-        for (var i = 0; i < clipboard_info.nodes.length; ++i) {
-            if (posMin){
-                if(posMin[0]>clipboard_info.nodes[i].pos[0]){
-                    posMin[0] = clipboard_info.nodes[i].pos[0];
-                    posMinIndexes[0] = i;
+        
+
+        var constantPasteOffset = 5;
+        var pasteOffsetX = constantPasteOffset;
+        var pasteOffsetY = constantPasteOffset;
+
+        if (calculatePasteOffset)
+        {
+            for (var i = 0; i < clipboard_info.nodes.length; ++i) {
+                if (posMin){
+                    if(posMin[0]>clipboard_info.nodes[i].pos[0]){
+                        posMin[0] = clipboard_info.nodes[i].pos[0];
+                        posMinIndexes[0] = i;
+                    }
+                    if(posMin[1]>clipboard_info.nodes[i].pos[1]){
+                        posMin[1] = clipboard_info.nodes[i].pos[1];
+                        posMinIndexes[1] = i;
+                    }
                 }
-                if(posMin[1]>clipboard_info.nodes[i].pos[1]){
-                    posMin[1] = clipboard_info.nodes[i].pos[1];
-                    posMinIndexes[1] = i;
+                else{
+                    posMin = [clipboard_info.nodes[i].pos[0], clipboard_info.nodes[i].pos[1]];
+                    posMinIndexes = [i, i];
                 }
             }
-            else{
-                posMin = [clipboard_info.nodes[i].pos[0], clipboard_info.nodes[i].pos[1]];
-                posMinIndexes = [i, i];
-            }
+
+            pasteOffsetX = this.graph_mouse[0] - posMin[0];
+            pasteOffsetY = this.graph_mouse[1] - posMin[1];
         }
+
         var nodes = [];
         for (var i = 0; i < clipboard_info.nodes.length; ++i) {
             var node_data = clipboard_info.nodes[i];
@@ -7233,8 +7255,8 @@ LGraphNode.prototype.executeAction = function(action)
                 node.configure(node_data);
         
 				//paste in last known mouse position
-                node.pos[0] += this.graph_mouse[0] - posMin[0]; //+= 5;
-                node.pos[1] += this.graph_mouse[1] - posMin[1]; //+= 5;
+                node.pos[0] += pasteOffsetX; //+= 5;
+                node.pos[1] += pasteOffsetY; //+= 5;
 
                 this.graph.add(node,{doProcessChange:false});
                 
@@ -7263,6 +7285,23 @@ LGraphNode.prototype.executeAction = function(action)
         }
 
         this.selectNodes(nodes);
+    }
+    LGraphCanvas.prototype.pasteFromClipboard = function(isConnectUnselected = false) {
+        // if ctrl + shift + v is off, return when isConnectUnselected is true (shift is pressed) to maintain old behavior
+        if (!LiteGraph.ctrl_shift_v_paste_connect_unselected_outputs && isConnectUnselected) {
+            return;
+        }
+        var data = localStorage.getItem("litegrapheditor_clipboard");
+
+        if (!data) {
+            return;
+        }
+
+        this.graph.beforeChange();
+
+        //create nodes
+        var clipboard_info = JSON.parse(data);
+        this.pasteFromClipboardWithData(clipboard_info, isConnectUnselected);
 
 		this.graph.afterChange();
     };


### PR DESCRIPTION
https://github.com/comfyanonymous/ComfyUI/issues/1544

I've been using this for 6 months in my local ComfyUI install, and so far I only had one issue:

Sometimes, when Alt+Shift+dragging a node or a selection of nodes, some of the incoming connections don't get cloned. Apart from that, I didn't experience any other problems. Also, since I stopped using Ctrl+C and Ctrl+Shift+V entirely after writing this patch, I don't know if this issue happens in the original code as well.

That said, I wrote this 6 months ago and my memory is vague on the details, but here is a copy of my comments on this patch from around the time I wrote it (copied from the comfyui issue linked above) for context:

> Changes:
> 
> - Alt+Drag clones entire selection, 1 node or many.
> - Alt+Shift+Drag same as above, but like Ctrl+Shift+V, clones with incoming branches
> 
> Limitations:
> 
> - Alt+Shift+Drag for single nodes only works if the node was already selected.
> - The currently selected node detection after cloned nodes are added is jank, just finds it from mouse coords, no idea if it works as it should. The intent is to have a cloned node of the one under cursor designated as the "draggee", probably should just search it in the paste stage and match by id.
> 
> Description:
> Uses the clipboard copy-paste logic, skipping the JSON encode/decode and storing to local storage.
> 
> Note:
> The patch was exported ignoring whitespace changes. The original litegraph.core.js file has inconsistent indentation (mixes tabs and spaces) and lots of trailing spaces. My editor trims trailing spaces on save. Should work, but who knows. I don't write Javascript much.